### PR TITLE
Fix Ren'Py incremental translation integrity

### DIFF
--- a/frontend/RenpyToolbox/OneKeyTranslatePage.py
+++ b/frontend/RenpyToolbox/OneKeyTranslatePage.py
@@ -4,6 +4,7 @@ YiJianFanyiPage - 一键翻译向导页面
 """
 
 import os
+import shutil
 import time
 from pathlib import Path
 from PyQt5.QtCore import Qt, QThread, pyqtSignal, QTimer
@@ -49,6 +50,17 @@ from module.Extract.PatchGenerator import generate_patch
 from module.Extract.UnifiedExtractor import UnifiedExtractor
 from module.Renpy import renpy_extract as rx
 from frontend.TranslationPage import TranslationPage
+
+
+def configure_incremental_translation_paths(config, game_dir, tl_name, incremental_dir):
+    """Point translation at the extracted delta while preserving the main TL target."""
+    project_root = Path(game_dir)
+    main_tl_dir = project_root / "game" / "tl" / tl_name
+    delta_dir = Path(incremental_dir)
+    output_dir = project_root / "RenpyBox_Translation" / f"{tl_name}_new"
+    config.input_folder = str(delta_dir)
+    config.output_folder = str(output_dir)
+    return main_tl_dir, output_dir
 
 # Worker Thread for Extraction
 class ExtractionWorker(QThread):
@@ -1017,23 +1029,24 @@ class YiJianFanyiPage(Base, QWidget):
                     f"原有翻译保持不变，可分别处理新增内容。"
                 )
                 self._incremental_dir = result.incremental_dir
-                try:
-                    from module.Config import Config
-                    auto_merge_enabled = getattr(Config().load(), "renpy_incremental_auto_merge_cleanup", True)
-                except Exception:
-                    auto_merge_enabled = False
-                if auto_merge_enabled:
-                    tl_name = self.tl_folder_edit.text().strip() or "chinese"
-                    merge_result = self.unified_extractor.merge_incremental_folder(
-                        self.game_dir,
-                        tl_name,
-                        result.incremental_dir,
-                        clean_duplicates=True,
-                    )
-                    if merge_result.success:
-                        detail_msg = detail_msg + f"\n✅ 已自动合并并清理重复：{merge_result.message}"
-                    else:
-                        detail_msg = detail_msg + f"\n⚠ 自动合并失败：{merge_result.message}"
+                # Keep the staging directory until it has been translated.  Merging
+                # here deletes it and makes the translation page fall back to the
+                # complete main language directory.
+                from module.Config import Config
+                tl_name = self.tl_folder_edit.text().strip() or "chinese"
+                config = Config().load()
+                apply_target, delta_output = configure_incremental_translation_paths(
+                    config, self.game_dir, tl_name, result.incremental_dir
+                )
+                shutil.rmtree(str(delta_output), ignore_errors=True)
+                delta_output.mkdir(parents=True, exist_ok=True)
+                config.save()
+                self._apply_target_dir = apply_target
+                self._incremental_output_dir = delta_output
+                detail_msg += (
+                    f"\n增量翻译输入：{result.incremental_dir.name}/"
+                    f"\n增量翻译输出：{delta_output.name}/"
+                )
             else:
                 detail_msg = f'{msg}\n已保留占位（new==old），可直接进入翻译。需要更新术语/禁翻后可再次点击"重新抽取"。'
                 self._incremental_dir = None
@@ -1640,8 +1653,9 @@ class YiJianFanyiPage(Base, QWidget):
         config = Config().load()
         
         # 验证路径
-        output_dir = Path(config.output_folder)
-        input_dir = Path(config.input_folder)
+        incremental_output = getattr(self, "_incremental_output_dir", None)
+        output_dir = Path(incremental_output or config.output_folder)
+        input_dir = Path(getattr(self, "_apply_target_dir", config.input_folder))
         
         if not output_dir.exists():
             InfoBar.error("错误", f"输出目录不存在：{output_dir}", parent=self)
@@ -1677,7 +1691,34 @@ class YiJianFanyiPage(Base, QWidget):
         if not msg_box.exec():
             return
         
-        # 执行复制
+        # Apply translated incremental files through the semantic merger.  A
+        # delta file contains only selected entries and must never overwrite the
+        # complete target file byte-for-byte.
+        if incremental_output:
+            try:
+                tl_name = self.tl_folder_edit.text().strip() or "chinese"
+                merge_result = self.unified_extractor.merge_incremental_folder(
+                    self.game_dir,
+                    tl_name,
+                    output_dir,
+                    clean_duplicates=True,
+                )
+                if not merge_result.success:
+                    InfoBar.warning("合并失败", merge_result.message, parent=self)
+                    return
+                staging_input = getattr(self, "_incremental_dir", None)
+                if staging_input and Path(staging_input).exists():
+                    shutil.rmtree(str(staging_input), ignore_errors=True)
+                self._incremental_dir = None
+                self._incremental_output_dir = None
+                InfoBar.success("应用成功", merge_result.message, duration=5000, parent=self)
+                return
+            except Exception as e:
+                self.logger.error(f"应用增量翻译失败: {e}")
+                InfoBar.error("错误", f"应用增量翻译失败：{e}", parent=self)
+                return
+
+        # Full translation mode keeps the legacy whole-file copy behavior.
         try:
             success_count = 0
             failed_files = []
@@ -1789,4 +1830,3 @@ class YiJianFanyiPage(Base, QWidget):
 # 兼容旧引用
 OneKeyTranslatePage = YiJianFanyiPage
 __all__ = ["YiJianFanyiPage", "OneKeyTranslatePage"]
-

--- a/module/Extract/ReplaceGenerator.py
+++ b/module/Extract/ReplaceGenerator.py
@@ -21,6 +21,7 @@ from typing import Any, List, Optional, Sequence, Set, Tuple
 from base.Base import Base
 from base.LogManager import LogManager
 from module.Extract.SimpleRpyExtractor import SimpleRpyExtractor
+from module.Renpy import renpy_extract as rx
 from module.Text.SkipRules import should_skip_text
 
 Pair = Tuple[str, str]
@@ -31,7 +32,7 @@ LEGACY_MISS_TXT = "miss_ready_replace.txt"
 MISS_DIR = "miss"
 REGEX_CACHE = "regex_extracted.json"  # 正则提取缓存
 HOOK_MANIFEST = "hook_translate_manifest.json"
-REGEX_CACHE_VERSION = 1
+REGEX_CACHE_VERSION = 2  # 宽松引号扫描规则已修正，必须作废旧候选缓存。
 RE_RELAXED_ENGLISH_SOURCE_LINE = re.compile(
     r'^(?!.*#)(?!\s*translate\s+\w+\b)(?=.*\b[A-Za-z]{3,}\b).*$',
     re.IGNORECASE,
@@ -271,8 +272,9 @@ def _extract_relaxed_english_line_literals(line: str) -> Set[str]:
 
     说明：
     - 对应用户提供的规则：`^(?!.*#)^(?!.*translate schinese)(?=.*\\b[A-Za-z]{3,}\\b).*$`
-    - 这里将 `translate schinese` 泛化为 `translate <lang>`，避免只对某个语言标签生效
-    - 命中后只提取引号里的文本，不把整行代码直接当作待翻译文本
+    - 这里将 `translate schinese` 泛化为 `translate <lang>`，避免只对某个语言标签生效。
+    - 命中后只提取引号里的文本，不把整行代码直接当作待翻译文本。
+    - 单引号需额外判断是否处于双引号台词内，避免缩写被误抽取。
     """
     stripped = line.strip()
     if not stripped:
@@ -280,21 +282,13 @@ def _extract_relaxed_english_line_literals(line: str) -> Set[str]:
     if RE_RELAXED_ENGLISH_SOURCE_LINE.match(stripped) is None:
         return set()
 
-    result: Set[str] = set()
-    for pattern in (RE_RELAXED_DOUBLE_QUOTED, RE_RELAXED_SINGLE_QUOTED):
-        for match in pattern.finditer(line):
-            prefix = line[:match.start()].rstrip()
-            # 宽松补抓不处理明显的函数参数字符串，避免把 ShowMenu("gallery") 之类带进来。
-            if RE_RELAXED_FUNCTION_CALL_PREFIX.search(prefix):
-                continue
-            text = _unescape(match.group(1))
-            if not text:
-                continue
-            if RE_RELAXED_ENGLISH_WORD.search(text) is None:
-                continue
-            result.add(text)
-
-    return result
+    # 复用标准 Ren'Py 补充抽取器的宽松规则，避免「补全翻译」钩子流程
+    # 与标准/增量 TL 流程对单引号、缩写、行内语句的判断出现分叉。
+    return {
+        _unescape(text)
+        for text in rx.extract_relaxed_english_line_literals(line, filter_length=4)
+        if text and RE_RELAXED_ENGLISH_WORD.search(_unescape(text)) is not None
+    }
 
 
 def _is_character_name(text: str) -> bool:
@@ -763,6 +757,8 @@ def collect_hook_translation_entries(
 
     logger.info("正在扫描 HOOK 缺失文本...")
     regex_filtered = set(collect_glossary_candidate_texts(target_path, tl_name = tl_name))
+    # 可写入标准 TL 的静态文本必须由增量抽取处理，不能落入 replace_text。
+    regex_filtered -= set(rx.collect_static_source_strings(game_dir).keys())
 
     logger.info("正在读取 tl 已覆盖文本...")
     tl_covered = _get_tl_covered_strings(target_path, tl_name)
@@ -1260,6 +1256,44 @@ def build_replace_pairs_from_entries(entries: Sequence[Any]) -> List[Pair]:
     return sorted(mapping.items(), key=lambda item: (-len(item[0]), item[0]))
 
 
+def filter_replace_pairs_covered_by_tl(
+    pairs: Sequence[Pair], target_path: str | Path, tl_name: str
+) -> List[Pair]:
+    """Drop hook replacements that became covered by normal TL before writeback."""
+    covered = _get_tl_covered_strings(target_path, tl_name)
+    game_dir = _get_game_dir(target_path)
+    old_re = re.compile(r'^\s*old\s+["\'](?P<text>.*)["\']\s*$')
+    tl_dir = game_dir / "tl" / tl_name
+    for tl_file in tl_dir.rglob("*.rpy") if tl_dir.is_dir() else ():
+        try:
+            for line in tl_file.read_text(
+                encoding="utf-8", errors="replace"
+            ).splitlines():
+                match = old_re.match(line)
+                if match:
+                    covered.add(match.group("text"))
+        except Exception:
+            continue
+    for source_file in game_dir.rglob("*.rpy"):
+        try:
+            relative = source_file.relative_to(game_dir)
+            if relative.parts and relative.parts[0].lower() == "tl":
+                continue
+            for line in source_file.read_text(
+                encoding="utf-8", errors="replace"
+            ).splitlines():
+                match = old_re.match(line)
+                if match:
+                    covered.add(match.group("text"))
+        except Exception:
+            continue
+    return [
+        (original, translation)
+        for original, translation in pairs
+        if not any(original == text or original in text for text in covered)
+    ]
+
+
 def render_replace_script(
     pairs: Sequence[Pair],
     *,
@@ -1289,10 +1323,28 @@ def render_replace_script(
 
     if wrap_existing:
         lines.append(f"    {previous_name} = getattr(config, \"replace_text\", None)")
+        lines.append("    _renpybox_seen_hooks = set()")
+        lines.append(f"    while getattr({previous_name}, \"_renpybox_auto_hook\", False):")
+        lines.append(f"        if id({previous_name}) in _renpybox_seen_hooks:")
+        lines.append(f"            {previous_name} = None")
+        lines.append("            break")
+        lines.append(f"        _renpybox_seen_hooks.add(id({previous_name}))")
+        lines.append(
+            f"        _renpybox_next_hook = getattr({previous_name}, \"_renpybox_previous\", None)"
+        )
+        lines.append(f"        if _renpybox_next_hook is {previous_name}:")
+        lines.append(f"            {previous_name} = None")
+        lines.append("            break")
+        lines.append(f"        {previous_name} = _renpybox_next_hook")
         lines.append("")
 
+    function_args = (
+        f"{target_name}, _renpybox_previous={previous_name}"
+        if wrap_existing
+        else target_name
+    )
     lines.extend([
-        f"    def {function_name}({target_name}):",
+        f"    def {function_name}({function_args}):",
         "",
         f"        if not isinstance({target_name}, str):",
         f"            return {target_name}",
@@ -1301,8 +1353,8 @@ def render_replace_script(
 
     if wrap_existing:
         lines.extend([
-            f"        if callable({previous_name}) and {previous_name} is not {function_name}:",
-            f"            {target_name} = {previous_name}({target_name})",
+            f"        if callable(_renpybox_previous) and _renpybox_previous is not {function_name}:",
+            f"            {target_name} = _renpybox_previous({target_name})",
             f"            if not isinstance({target_name}, str):",
             f"                return {target_name}",
             "",
@@ -1321,6 +1373,8 @@ def render_replace_script(
 
     if assign_to_config:
         lines.append("")
+        lines.append(f"    {function_name}._renpybox_auto_hook = True")
+        lines.append(f"    {function_name}._renpybox_previous = {previous_name}")
         lines.append(f"    config.replace_text = {function_name}")
 
     lines.append("")

--- a/module/Extract/UnifiedExtractor.py
+++ b/module/Extract/UnifiedExtractor.py
@@ -27,7 +27,11 @@ from module.Extract.RenpyExtractor import RenpyExtractor
 from module.Extract.MaExtractor import MaExtractor
 from module.Extract.JsonExtractor import JsonExtractor
 from module.Renpy.renpy_tl_io import RenpyTlItemExtractor
-from module.Renpy.renpy_tl_core import parse_tl_document
+from module.Renpy.renpy_tl_core import (
+    parse_tl_document,
+    scan_quoted_literals,
+    escape_tl_string,
+)
 from module.Renpy.renpy_tl_io import RenpyTlLineUpdater
 from module.Renpy.renpy_tl_core import TlStmtKind
 from module.Renpy import renpy_extract as rx
@@ -486,7 +490,7 @@ class UnifiedExtractor:
                         if new_match:
                             new_value = self._decode_literal_value(new_match.group(1), new_match.group("text"))
 
-                    if old_value in base_old_set and (not new_value or new_value == old_value):
+                    if old_value in base_old_set:
                         removed_total += 1
                         changed = True
                         i = j + 1 if j > i else i + 1
@@ -513,6 +517,94 @@ class UnifiedExtractor:
                 pass
 
         return removed_total
+
+    def _collect_source_registered_old_values(self, game_dir: Path, tl_name: str) -> Set[str]:
+        """Collect strings already registered by translate blocks outside game/tl."""
+        game_root = game_dir / "game"
+        if not game_root.is_dir():
+            return set()
+        header_re = re.compile(
+            rf"^\s*translate\s+{re.escape(tl_name)}\s+strings\s*:\s*$"
+        )
+        values: Set[str] = set()
+        for source_file in game_root.rglob("*.rpy"):
+            try:
+                relative = source_file.relative_to(game_root)
+                if relative.parts and relative.parts[0].lower() == "tl":
+                    continue
+                lines = source_file.read_text(
+                    encoding="utf-8", errors="replace"
+                ).splitlines()
+            except Exception:
+                continue
+            in_strings = False
+            for line in lines:
+                if header_re.match(line):
+                    in_strings = True
+                    continue
+                if in_strings and re.match(r"^\s*translate\s+", line):
+                    in_strings = False
+                if not in_strings:
+                    continue
+                old_match = self.OLD_LINE_RE.match(line)
+                if old_match:
+                    values.add(
+                        self._decode_literal_value(
+                            old_match.group(1), old_match.group("text")
+                        )
+                    )
+        return values
+
+    def _remove_source_registered_string_duplicates(
+        self, game_dir: Path, tl_dir: Path, tl_name: str
+    ) -> int:
+        """Remove TL old/new entries already registered directly by game source."""
+        source_values = self._collect_source_registered_old_values(game_dir, tl_name)
+        if not source_values:
+            return 0
+        removed = 0
+        for rpy_file in tl_dir.rglob("*.rpy"):
+            try:
+                lines = rpy_file.read_text(
+                    encoding="utf-8", errors="replace"
+                ).splitlines()
+            except Exception:
+                continue
+            output: List[str] = []
+            i = 0
+            changed = False
+            while i < len(lines):
+                old_match = self.OLD_LINE_RE.match(lines[i])
+                if old_match:
+                    old_value = self._decode_literal_value(
+                        old_match.group(1), old_match.group("text")
+                    )
+                    j = i + 1
+                    while j < len(lines) and (
+                        not lines[j].strip() or lines[j].lstrip().startswith("#")
+                    ):
+                        j += 1
+                    if (
+                        old_value in source_values
+                        and j < len(lines)
+                        and self.NEW_LINE_RE.match(lines[j])
+                    ):
+                        while output and (
+                            not output[-1].strip()
+                            or output[-1].lstrip().startswith("# game/")
+                        ):
+                            output.pop()
+                        removed += 1
+                        changed = True
+                        i = j + 1
+                        continue
+                output.append(lines[i])
+                i += 1
+            if changed:
+                rpy_file.write_text("\n".join(output).rstrip() + "\n", encoding="utf-8")
+        if removed:
+            self._remove_empty_translate_blocks(tl_dir, tl_name)
+        return removed
 
     def _load_glossary_map(self, config: Config) -> Dict[str, str]:
         """加载用户术语库，返回 {原文: 译文}。"""
@@ -607,6 +699,20 @@ class UnifiedExtractor:
             return decoded if isinstance(decoded, str) else str(decoded)
         except Exception:
             return value.replace('\\"', '"').replace("\\'", "'")
+
+    @classmethod
+    def _canonical_rpy_string(cls, quote: str, value: str) -> str:
+        """Decode a TL literal and collapse legacy double-escaped quotes."""
+        decoded = cls._decode_rpy_string(quote, value)
+        # Older incremental output escaped an already escaped raw literal.  Ren'Py
+        # then sees ``\\\"`` as a literal backslash followed by a quote, while the
+        # original source value is just the quote.  Canonicalize before comparing
+        # or re-emitting so both spellings have one global owner.
+        previous = None
+        while decoded != previous:
+            previous = decoded
+            decoded = decoded.replace('\\"', '"').replace("\\'", "'")
+        return decoded
 
     def get_last_suspicious_manifest(self) -> Optional[Path]:
         return self._last_suspicious_manifest
@@ -1087,9 +1193,12 @@ class UnifiedExtractor:
             else:
                 self.logger.info("根据配置跳过补充抽取阶段")
             
-            # 4. 过滤与清理 + 终极结构导出
+            # 4. 静态补充抽取：把官方/自定义流程仍可能漏掉的源码文本写入标准 TL。
+            self._append_static_supplement_entries(game_dir, tl_dir, tl_name)
+
+            # 5. 过滤与清理 + 终极结构导出
             self._post_process(game_dir, tl_name, tl_dir, config, None)
-            # 5. 注入内置 UI 包（common_box/screens_box）
+            # 6. 注入内置 UI 包（common_box/screens_box）
             injected_ui = 0
             if getattr(config, "onekey_inject_base_box", False):
                 injected_ui = self._deploy_builtin_ui_pack(tl_dir, tl_name)
@@ -1159,6 +1268,10 @@ class UnifiedExtractor:
                 return result
 
             self._emit_progress("正在分析已有翻译...", 10)
+
+            repaired_comments = self._repair_block_comments_from_source(game_dir, tl_dir)
+            if repaired_comments:
+                self.logger.info(f"已按游戏源码修正 {repaired_comments} 条翻译块原文注释")
             
             # 1. 获取已翻译内容 {original: translated}
             existing_translations = self._get_existing_translations(tl_dir)
@@ -1168,13 +1281,14 @@ class UnifiedExtractor:
             
             # 2. 获取当前所有原文（用于后续对比新增）
             existing_originals = set(existing_translations.keys())
-            all_current_originals = self._get_all_originals(tl_dir)
+            existing_string_originals = self._get_all_originals(tl_dir)
             block_originals = self._collect_block_originals(tl_dir)
-            if block_originals:
-                all_current_originals |= block_originals
-                self.logger.info(f"翻译块原文 {len(block_originals)} 条已计入已存在集合")
-            self.logger.info(f"当前共 {len(all_current_originals)} 条原文")
-            
+            all_current_originals = existing_string_originals | block_originals
+            self.logger.info(
+                f"当前覆盖 {len(all_current_originals)} 条原文 "
+                f"(strings={len(existing_string_originals)}, blocks={len(block_originals)})"
+            )
+
             # 3. 创建临时目录进行抽取
             temp_extract_dir = game_dir / f"_temp_extract_{tl_name}_{int(time.time())}"
             temp_tl_dir = temp_extract_dir / "game" / "tl" / tl_name
@@ -1242,11 +1356,20 @@ class UnifiedExtractor:
                     _relocate_dir(temp_backup_dir, tl_dir, remove_src=True)
                 
                 # 6. 获取新抽取的所有原文
+                # 静态源码文本必须写入标准 TL，不交给 replace_text。
+                static_candidates = rx.collect_static_source_strings(game_dir)
+                self._append_static_supplement_entries(game_dir, temp_tl_dir, tl_name)
                 new_extracted_originals = self._get_all_originals(temp_tl_dir)
                 self.logger.info(f"新抽取共 {len(new_extracted_originals)} 条原文")
                 
                 # 7. 计算新增原文
-                new_originals = new_extracted_originals - all_current_originals
+                new_originals = self._select_incremental_originals(
+                    new_extracted_originals,
+                    existing_string_originals,
+                    block_originals,
+                    static_candidates,
+                    tl_dir,
+                )
                 self.logger.info(f"检测到 {len(new_originals)} 条新增原文")
                 result.new_strings = len(new_originals)
 
@@ -1254,8 +1377,11 @@ class UnifiedExtractor:
                 if output_to_separate_folder and getattr(config, "renpy_incremental_include_untranslated", False):
                     # tl 已存在但没翻译过/只有占位（new==old/new==""）时，把这些也纳入待翻译包
                     pending_originals = self._get_untranslated_originals(tl_dir)
-                    if block_originals:
-                        pending_originals -= block_originals
+                    # Dialogue coverage suppresses synthetic dialogue placeholders,
+                    # but an explicit strings placeholder (for example a menu
+                    # choice) must still be translated even when equal dialogue
+                    # exists elsewhere.
+                    pending_originals -= block_originals - existing_string_originals
                     pending_originals -= set(existing_translations.keys())
                     self.logger.info(f"检测到 {len(pending_originals)} 条未翻译占位原文")
 
@@ -1269,7 +1395,7 @@ class UnifiedExtractor:
                     incremental_dir.mkdir(parents=True, exist_ok=True)
                     
                     self._extract_new_entries_to_folder(
-                        temp_tl_dir, incremental_dir, selected_originals, tl_name
+                        temp_tl_dir, incremental_dir, selected_originals, tl_name, game_dir
                     )
                     
                     # 统计输出文件
@@ -1371,14 +1497,10 @@ class UnifiedExtractor:
             return result
 
         def decode_literal(quote: str, text: str) -> str:
-            literal = f"{quote}{text}{quote}"
-            try:
-                return ast.literal_eval(literal)
-            except Exception:
-                return text.replace('\\"', '"').replace("\\'", "'")
+            return self._canonical_rpy_string(quote, text)
 
-        def collect_pairs(lines: List[str]) -> List[Tuple[str, str]]:
-            pairs: List[Tuple[str, str]] = []
+        def collect_pairs(lines: List[str]) -> List[Tuple[str, str, List[str]]]:
+            pairs: List[Tuple[str, str, List[str]]] = []
             i = 0
             while i < len(lines):
                 old_match = self.OLD_LINE_RE.match(lines[i])
@@ -1397,7 +1519,15 @@ class UnifiedExtractor:
                     if new_match:
                         old_value = decode_literal(old_match.group(1), old_match.group("text"))
                         new_value = decode_literal(new_match.group(1), new_match.group("text"))
-                        pairs.append((old_value, new_value))
+                        comments: List[str] = []
+                        back = i - 1
+                        while back >= 0 and (
+                            not lines[back].strip() or lines[back].lstrip().startswith("#")
+                        ):
+                            if lines[back].lstrip().startswith("# game/"):
+                                comments.insert(0, lines[back].strip())
+                            back -= 1
+                        pairs.append((old_value, new_value, comments))
                         i = j + 1
                         continue
                 i += 1
@@ -1464,10 +1594,10 @@ class UnifiedExtractor:
                 continue
 
             target_map = collect_target_map(target_lines)
-            new_entries: List[Tuple[str, str]] = []
+            new_entries: List[Tuple[str, str, List[str]]] = []
             changed = False
 
-            for old_text, new_text in inc_pairs:
+            for old_text, new_text, comments in inc_pairs:
                 if old_text in target_map:
                     current_new, new_line_idx = target_map[old_text]
                     if (not current_new or current_new == old_text) and new_text and new_text != old_text:
@@ -1479,17 +1609,36 @@ class UnifiedExtractor:
                         updated_entries += 1
                         changed = True
                     continue
-                new_entries.append((old_text, new_text))
+                new_entries.append((old_text, new_text, comments))
 
             if new_entries:
-                append_lines = ["", "# 增量合并", f"translate {tl_name} strings:", ""]
-                for old_text, new_text in new_entries:
+                append_lines: List[str] = []
+                for old_text, new_text, comments in new_entries:
+                    append_lines.extend(f"    {comment}" for comment in comments)
                     escaped_old = self._escape_rpy_string(old_text)
                     escaped_new = self._escape_rpy_string(new_text) if new_text else ""
                     append_lines.append(f'    old "{escaped_old}"')
                     append_lines.append(f'    new "{escaped_new}"')
                     append_lines.append("")
-                target_lines.extend(append_lines)
+
+                strings_header = re.compile(
+                    rf"^\s*translate\s+{re.escape(tl_name)}\s+strings\s*:\s*$"
+                )
+                header_indexes = [
+                    index for index, line in enumerate(target_lines) if strings_header.match(line)
+                ]
+                if header_indexes:
+                    header_index = header_indexes[-1]
+                    insert_at = len(target_lines)
+                    for index in range(header_index + 1, len(target_lines)):
+                        if re.match(r"^\s*translate\s+", target_lines[index]):
+                            insert_at = index
+                            break
+                    while insert_at > header_index + 1 and not target_lines[insert_at - 1].strip():
+                        insert_at -= 1
+                    target_lines[insert_at:insert_at] = [""] + append_lines
+                else:
+                    target_lines.extend(["", f"translate {tl_name} strings:", ""] + append_lines)
                 added_entries += len(new_entries)
                 changed = True
 
@@ -1507,50 +1656,303 @@ class UnifiedExtractor:
                 removed = self._remove_string_duplicates_with_blocks(tl_dir)
                 if removed:
                     self.logger.info(f"已移除 {removed} 条与翻译块重复的 strings 翻译")
-            if getattr(config, "onekey_inject_base_box", False):
+            # base_box 一旦存在就会被 Ren'Py 加载；即使本次未启用注入，
+            # 也要清理它与增量占位条目的重复。
+            if (tl_dir / "base_box").exists():
                 removed_ui = self._remove_placeholder_duplicates_for_base_box(tl_dir, tl_name)
                 if removed_ui:
                     self.logger.info(f"已按 base_box 优先清理占位重复 {removed_ui} 条")
+            removed_source = self._remove_source_registered_string_duplicates(
+                game_dir, tl_dir, tl_name
+            )
+            if removed_source:
+                self.logger.info(f"已清理与游戏源码翻译重复的 strings 条目 {removed_source} 条")
             try:
                 removed_blocks = self._remove_empty_translate_blocks(tl_dir, tl_name)
                 if removed_blocks:
                     self.logger.info(f"已移除 {removed_blocks} 个空的 translate strings 块")
             except Exception:
                 pass
+            removed_truncated = self._remove_strings_covered_by_truncated_block_comment(tl_dir)
+            if removed_truncated:
+                self.logger.info(
+                    f"已清理 {removed_truncated} 条由官方截断注释造成的伪 strings 重复"
+                )
+
+        # 合并与去重成功后，增量目录不再是可加载的翻译来源，
+        # 避免遗留目录造成重复加载和困惑。
+        try:
+            shutil.rmtree(str(incremental_dir))
+        except Exception as exc:
+            self.logger.warning(f"合并完成但清理增量目录失败 {incremental_dir}: {exc}")
 
         result.success = True
         result.total_files = len(list(self._iter_rpy_files(tl_dir)))
         result.message = (
             f"合并完成：更新占位 {updated_entries} 条，"
-            f"新增 {added_entries} 条，涉及 {merged_files} 个文件"
+            f"新增 {added_entries} 条，涉及 {merged_files} 个文件；已清理 {incremental_dir.name}"
         )
         return result
 
+    def _get_file_block_originals(self, rpy_file: Path) -> Set[str]:
+        """??????????? translate ?????????"""
+        if not rpy_file.exists():
+            return set()
+        try:
+            lines = rpy_file.read_text(encoding="utf-8", errors="replace").splitlines()
+        except Exception:
+            return set()
+
+        originals: Set[str] = set()
+        in_block = False
+        block_indent = 0
+        for line in lines:
+            stripped = line.lstrip()
+            indent = len(line) - len(stripped)
+            if stripped.startswith("translate ") and stripped.endswith(":"):
+                in_block = not stripped.endswith(" strings:")
+                block_indent = indent
+                continue
+            if not in_block:
+                continue
+            if stripped and indent <= block_indent:
+                in_block = False
+                continue
+            if stripped.startswith("#"):
+                match = re.search(r'"((?:\\.|[^"])*)"', stripped)
+                if match:
+                    originals.add(match.group(1).replace('\\"', '"').replace("\\'", "'"))
+        return originals
+
+    def _repair_block_comments_from_source(self, game_dir: Path, tl_dir: Path) -> int:
+        """Repair official TL template comments using their game/path:line anchors."""
+        repaired = 0
+        location_re = re.compile(r"^\s*#\s+(game/.+?):(\d+)\s*$")
+        source_cache: Dict[Path, List[str]] = {}
+
+        for tl_file in self._iter_rpy_files(tl_dir):
+            try:
+                lines = tl_file.read_text(encoding="utf-8", errors="replace").splitlines()
+            except Exception:
+                continue
+            changed = False
+
+            for index, line in enumerate(lines):
+                location = location_re.match(line)
+                if not location:
+                    continue
+                source_file = game_dir / location.group(1)
+                source_line_no = int(location.group(2))
+                if not source_file.is_file() or source_line_no <= 0:
+                    continue
+                source_lines = source_cache.get(source_file)
+                if source_lines is None:
+                    try:
+                        source_lines = source_file.read_text(
+                            encoding="utf-8", errors="replace"
+                        ).splitlines()
+                    except Exception:
+                        continue
+                    source_cache[source_file] = source_lines
+                if source_line_no > len(source_lines):
+                    continue
+                source_literals = scan_quoted_literals(source_lines[source_line_no - 1])
+                if not source_literals:
+                    continue
+                source_text = source_literals[-1].value
+
+                # Header, blank lines, then the official template comment.
+                for probe in range(index + 1, min(index + 10, len(lines))):
+                    stripped = lines[probe].lstrip()
+                    if probe > index + 1 and stripped.startswith("translate "):
+                        continue
+                    if not stripped.startswith("#") or stripped.startswith("# game/"):
+                        continue
+                    comment_literals = scan_quoted_literals(lines[probe])
+                    if not comment_literals:
+                        continue
+                    literal = comment_literals[-1]
+                    if literal.value == source_text:
+                        break
+                    replacement = f'"{escape_tl_string(source_text)}"'
+                    lines[probe] = (
+                        lines[probe][:literal.start_col]
+                        + replacement
+                        + lines[probe][literal.end_col:]
+                    )
+                    repaired += 1
+                    changed = True
+                    break
+
+            if changed:
+                tl_file.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+        return repaired
+
+    def _select_incremental_originals(
+        self,
+        extracted_originals: Set[str],
+        existing_string_originals: Set[str],
+        block_originals: Set[str],
+        static_candidates: Dict[str, str],
+        tl_dir: Path,
+    ) -> Set[str]:
+        """Select real incremental work without losing same-text menu strings."""
+        selected = extracted_originals - existing_string_originals - block_originals
+        menu_candidates = set(rx.collect_static_menu_strings(tl_dir.parents[2]))
+        file_block_cache: Dict[Path, Set[str]] = {}
+
+        # A source string covered by an official dialogue block is normally not
+        # incremental work.  The exception is a static strings use (notably a
+        # menu choice) whose corresponding TL file has no block for that text.
+        for original, relative_path in static_candidates.items():
+            if original not in extracted_originals or original in existing_string_originals:
+                continue
+            if original in menu_candidates:
+                selected.add(original)
+                continue
+            target_file = tl_dir / relative_path
+            file_blocks = file_block_cache.get(target_file)
+            if file_blocks is None:
+                file_blocks = self._get_file_block_originals(target_file)
+                file_block_cache[target_file] = file_blocks
+            if self._is_covered_by_file_block(original, file_blocks):
+                continue
+            selected.add(original)
+        return selected
+
+    @staticmethod
+    def _is_covered_by_file_block(original: str, file_blocks: Set[str]) -> bool:
+        """Match exact blocks plus official comments truncated at closing wrappers."""
+        if original in file_blocks:
+            return True
+
+        # Some official Ren'Py extraction comments drop the final wrapper from a
+        # parenthesized thought even though the source line contains it.  Treat
+        # only that narrow trailing-wrapper difference as coverage.
+        def without_trailing_wrapper(value: str) -> str:
+            return re.sub(r"\s*[\)\]\}]\s*$", "", value).rstrip()
+
+        normalized = without_trailing_wrapper(original)
+        if normalized == original.rstrip():
+            return False
+        return any(without_trailing_wrapper(value) == normalized for value in file_blocks)
+
+    def _remove_strings_covered_by_truncated_block_comment(self, tl_dir: Path) -> int:
+        """Remove only wrapper-mismatch duplicates; exact same-text menus remain."""
+        removed = 0
+        for rpy_file in self._iter_rpy_files(tl_dir):
+            file_blocks = self._get_file_block_originals(rpy_file)
+            if not file_blocks:
+                continue
+            try:
+                lines = rpy_file.read_text(encoding="utf-8", errors="replace").splitlines()
+            except Exception:
+                continue
+
+            indexes: Set[int] = set()
+            i = 0
+            while i < len(lines):
+                old_match = self.OLD_LINE_RE.match(lines[i])
+                if not old_match:
+                    i += 1
+                    continue
+                old_text = self._canonical_rpy_string(
+                    old_match.group(1), old_match.group("text")
+                )
+                # Exact equality may be a real menu string.  Only remove the
+                # narrow case where coverage exists after dropping a final
+                # wrapper from the official block comment.
+                if old_text in file_blocks or not self._is_covered_by_file_block(old_text, file_blocks):
+                    i += 1
+                    continue
+                j = i + 1
+                while j < len(lines) and (not lines[j].strip() or lines[j].lstrip().startswith("#")):
+                    j += 1
+                if j < len(lines) and self.NEW_LINE_RE.match(lines[j]):
+                    indexes.update(range(i, j + 1))
+                    removed += 1
+                    i = j + 1
+                    continue
+                i += 1
+
+            if indexes:
+                kept = [line for index, line in enumerate(lines) if index not in indexes]
+                rpy_file.write_text("\n".join(kept).rstrip() + "\n", encoding="utf-8")
+        return removed
+
+    def _append_static_supplement_entries(
+        self,
+        game_dir: Path,
+        tl_dir: Path,
+        tl_name: str,
+    ) -> int:
+        """把静态漏抽文本写入其首次出现的标准翻译文件。"""
+        candidates = rx.collect_static_source_strings(game_dir)
+        menu_candidates = set(rx.collect_static_menu_strings(game_dir))
+        if not candidates:
+            return 0
+
+        existing = self._get_all_originals(tl_dir)
+        added = 0
+        for original, relative_path in candidates.items():
+            if original in existing:
+                continue
+
+            target_file = tl_dir / relative_path
+            # ??????????????????????????????????
+            if (
+                original not in menu_candidates
+                and original in self._get_file_block_originals(target_file)
+            ):
+                continue
+            target_file.parent.mkdir(parents=True, exist_ok=True)
+            escaped = self._escape_rpy_string(original)
+            source_file = (game_dir / "game" / relative_path)
+            source_line = self._find_source_text_line(source_file, original)
+            location_comment = (
+                f"    # game/{relative_path}:{source_line}\n"
+                if source_line is not None
+                else ""
+            )
+            with target_file.open("a", encoding="utf-8") as handle:
+                handle.write(
+                    f"\ntranslate {tl_name} strings:\n\n"
+                    f"{location_comment}"
+                    f'    old "{escaped}"\n'
+                    f'    new "{escaped}"\n'
+                )
+            existing.add(original)
+            added += 1
+
+        if added:
+            self.logger.info(f"标准补充抽取：已添加 {added} 条静态翻译条目")
+        return added
+
+    @staticmethod
+    def _find_source_text_line(source_file: Path, original: str) -> Optional[int]:
+        try:
+            lines = source_file.read_text(encoding="utf-8", errors="replace").splitlines()
+        except Exception:
+            return None
+        for line_no, line in enumerate(lines, 1):
+            if any(literal.value == original for literal in scan_quoted_literals(line)):
+                return line_no
+        return None
+
     def _get_all_originals(self, tl_dir: Path) -> Set[str]:
-        """获取 tl 目录中所有的原文"""
-        originals = set()
+        """获取 translate strings 中真实 old 条目的原文。"""
+        originals: Set[str] = set()
         if not tl_dir.exists():
             return originals
 
-        extractor = RenpyTlItemExtractor()
         for rpy_file in self._iter_rpy_files(tl_dir):
             try:
                 content = rpy_file.read_text(encoding="utf-8", errors="replace")
-                doc = parse_tl_document(content.splitlines())
-                items = extractor.extract(doc, str(rpy_file))
-                for item in items:
-                    originals.add(item.get_src())
-                continue
-            except Exception:
-                pass
-
-            try:
-                content = rpy_file.read_text(encoding="utf-8", errors="replace")
                 for match in self.OLD_LINE_RE.finditer(content):
-                    old_text = match.group("text").replace('\\"', '"').replace("\\'", "'")
+                    old_text = self._canonical_rpy_string(match.group(1), match.group("text"))
                     originals.add(old_text)
             except Exception:
-                pass
+                continue
         return originals
 
     def _get_untranslated_originals(self, tl_dir: Path) -> Set[str]:
@@ -1710,13 +2112,18 @@ class UnifiedExtractor:
         source_dir: Path,
         target_dir: Path,
         selected_originals: Set[str],
-        tl_name: str
+        tl_name: str,
+        game_dir: Optional[Path] = None,
     ):
         """将指定条目（新增/未翻译）提取到目标文件夹"""
         if not selected_originals:
             return
 
         extractor = RenpyTlItemExtractor()
+        menu_locations = (
+            rx.collect_static_menu_strings(game_dir) if game_dir is not None else {}
+        )
+        selected_menu_strings = selected_originals.intersection(menu_locations)
 
         for rpy_file in self._iter_rpy_files(source_dir):
             # AST 优先
@@ -1728,7 +2135,11 @@ class UnifiedExtractor:
                 if not items:
                     continue
 
-                selected_items = [item for item in items if item.get_src() in selected_originals]
+                selected_items = [
+                    item for item in items
+                    if item.get_src() in selected_originals
+                    and item.get_src() not in selected_menu_strings
+                ]
                 if not selected_items:
                     continue
 
@@ -1782,7 +2193,10 @@ class UnifiedExtractor:
                                 new_text = new_match.group("text")
 
                         # 只提取被选中的原文
-                        if old_text in selected_originals:
+                        if (
+                            old_text in selected_originals
+                            and old_text not in selected_menu_strings
+                        ):
                             new_entries.append((old_text, new_text))
 
                         i += 2
@@ -1814,6 +2228,108 @@ class UnifiedExtractor:
 
             except Exception as e:
                 self.logger.warning(f"处理文件失败 {rpy_file}: {e}")
+
+        if game_dir is not None:
+            for original in sorted(selected_menu_strings):
+                relative_path = menu_locations[original]
+                target_file = target_dir / relative_path
+                target_file.parent.mkdir(parents=True, exist_ok=True)
+                source_file = game_dir / "game" / relative_path
+                source_line = self._find_source_menu_line(source_file, original)
+                escaped = self._escape_rpy_string(original)
+                entry_lines = []
+                if source_line is not None:
+                    entry_lines.append(f"    # game/{relative_path}:{source_line}")
+                entry_lines.extend([f'    old "{escaped}"', f'    new "{escaped}"', ""])
+
+                if target_file.exists():
+                    lines = target_file.read_text(
+                        encoding="utf-8", errors="replace"
+                    ).splitlines()
+                else:
+                    lines = [
+                        "# 增量抽取 - 新增/待翻译内容",
+                        f"# 来源: {Path(relative_path).name}",
+                        "",
+                    ]
+                header_re = re.compile(
+                    rf"^\s*translate\s+{re.escape(tl_name)}\s+strings\s*:\s*$"
+                )
+                if not any(header_re.match(line) for line in lines):
+                    if lines and lines[-1].strip():
+                        lines.append("")
+                    lines.extend([f"translate {tl_name} strings:", ""])
+                lines.extend(entry_lines)
+                target_file.write_text(
+                    "\n".join(lines).rstrip() + "\n", encoding="utf-8"
+                )
+
+            self._annotate_incremental_string_locations(game_dir, target_dir)
+
+    def _annotate_incremental_string_locations(
+        self, game_dir: Path, target_dir: Path
+    ) -> int:
+        """Add source file and line comments to incremental old/new entries."""
+        added = 0
+        for target_file in self._iter_rpy_files(target_dir):
+            try:
+                relative_path = target_file.relative_to(target_dir)
+                source_file = game_dir / "game" / relative_path
+                if not source_file.is_file():
+                    continue
+                lines = target_file.read_text(
+                    encoding="utf-8", errors="replace"
+                ).splitlines()
+            except Exception:
+                continue
+            output: List[str] = []
+            changed = False
+            for line in lines:
+                old_match = self.OLD_LINE_RE.match(line)
+                if old_match:
+                    previous = next(
+                        (entry.strip() for entry in reversed(output) if entry.strip()), ""
+                    )
+                    if not previous.startswith("# game/"):
+                        original = self._decode_literal_value(
+                            old_match.group(1), old_match.group("text")
+                        )
+                        source_line = self._find_source_text_line(source_file, original)
+                        if source_line is not None:
+                            output.append(
+                                f"    # game/{relative_path.as_posix()}:{source_line}"
+                            )
+                            added += 1
+                            changed = True
+                output.append(line)
+            if changed:
+                target_file.write_text(
+                    "\n".join(output).rstrip() + "\n", encoding="utf-8"
+                )
+        return added
+
+    @staticmethod
+    def _find_source_menu_line(source_file: Path, original: str) -> Optional[int]:
+        menu_choice_re = re.compile(
+            r'^\s*"(?P<text>(?:\\.|[^"\\])*)"\s*(?:\([^)]*\))?\s*:\s*(?:#.*)?$'
+        )
+        try:
+            lines = source_file.read_text(
+                encoding="utf-8", errors="replace"
+            ).splitlines()
+        except Exception:
+            return None
+        for line_no, line in enumerate(lines, 1):
+            match = menu_choice_re.match(line)
+            if not match:
+                continue
+            try:
+                value = ast.literal_eval(f'"{match.group("text")}"')
+            except Exception:
+                value = match.group("text").replace('\\"', '"').replace("\\'", "'")
+            if value == original:
+                return line_no
+        return None
 
     def _merge_new_entries(
         self,
@@ -1991,7 +2507,12 @@ class UnifiedExtractor:
                     block = renpy.get("block")
                     if not isinstance(block, dict):
                         continue
-                    if str(block.get("kind")) == "LABEL":
+                    kind = block.get("kind")
+                    kind_value = getattr(kind, "value", kind)
+                    kind_text = str(kind_value)
+                    if kind_text.startswith("TlBlockKind."):
+                        kind_text = kind_text.split(".", 1)[1]
+                    if kind_text == "LABEL":
                         block_originals.add(item.get_src())
                 continue
             except Exception:
@@ -2032,62 +2553,10 @@ class UnifiedExtractor:
         return block_originals
 
     def _remove_string_duplicates_with_blocks(self, tl_dir: Path) -> int:
-        """
-        移除 translate strings 中与 translate 块原文重复的条目（优先保留块翻译）。
-        返回删除的条目数量。
-        """
-        block_originals = self._collect_block_originals(tl_dir)
-        if not block_originals:
-            return 0
-
-        removed = 0
-        for rpy_file in self._iter_rpy_files(tl_dir):
-            try:
-                lines = rpy_file.read_text(encoding="utf-8", errors="replace").splitlines()
-            except Exception:
-                continue
-
-            new_lines: List[str] = []
-            i = 0
-            changed = False
-
-            while i < len(lines):
-                line = lines[i]
-                match = self.OLD_LINE_RE.match(line)
-                if match:
-                    old_text = match.group("text").replace('\\"', '"').replace("\\'", "'")
-                    next_line = lines[i + 1] if i + 1 < len(lines) else ""
-                    new_match = self.NEW_LINE_RE.match(next_line)
-
-                    if old_text in block_originals:
-                        removed += 1
-                        changed = True
-                        # 跳过 old/new 行
-                        i += 2 if new_match else 1
-                        # 跳过紧随其后的空行，避免留下多余空白
-                        while i < len(lines) and not lines[i].strip():
-                            i += 1
-                        continue
-
-                new_lines.append(line)
-                i += 1
-
-            if changed:
-                final_lines: List[str] = []
-                prev_empty = False
-                for entry in new_lines:
-                    is_empty = not entry.strip()
-                    if is_empty and prev_empty:
-                        continue
-                    final_lines.append(entry)
-                    prev_empty = is_empty
-
-                try:
-                    rpy_file.write_text("\n".join(final_lines), encoding="utf-8")
-                except Exception:
-                    pass
-
-        return removed
+        """?? strings ???????????????? old ?????"""
+        del tl_dir
+        # Ren'Py ??? translate ??????? old ??????????????
+        return 0
 
     def _backup_tl_dir(self, game_dir: Path, tl_name: str):
         """备份 tl 目录"""
@@ -2136,6 +2605,12 @@ class UnifiedExtractor:
         except Exception as exc:
             self.logger.warning(f"去重失败 {tl_dir}: {exc}")
 
+        removed_source = self._remove_source_registered_string_duplicates(
+            project_root, tl_dir, tl_name
+        )
+        if removed_source:
+            self.logger.info(f"已清理与游戏源码翻译重复的 strings 条目 {removed_source} 条")
+
         # 移除与 translate 块重复的 strings 条目（保留块翻译，删掉 old/new）
         if getattr(config, "renpy_remove_string_duplicates", False):
             removed = self._remove_string_duplicates_with_blocks(tl_dir)
@@ -2143,7 +2618,7 @@ class UnifiedExtractor:
                 self.logger.info(f"已移除 {removed} 条与翻译块重复的 strings 翻译")
             
         # 移除 Hook 及工具型文件
-        if config.extract_skip_hook_files:
+        if getattr(config, "extract_skip_hook_files", False):
             self._prune_hook_files(tl_dir)
 
         # 清理空 translate strings 块，避免后续官方抽取报错
@@ -2172,7 +2647,7 @@ class UnifiedExtractor:
                 pass
 
         # 终极结构导出
-        if config.extract_export_excel:
+        if getattr(config, "extract_export_excel", False):
             if existing_translations is None:
                 existing_translations = self._get_existing_translations(tl_dir)
             try:

--- a/module/File/RENPY.py
+++ b/module/File/RENPY.py
@@ -340,5 +340,9 @@ class RENPY(Base):
             return False
 
     def _resolve_source_path(self, rel_path: str) -> Path:
+        input_path = self.input_path / rel_path
         target_path = self.output_path / rel_path
-        return target_path if target_path.exists() else self.input_path / rel_path
+        # Cache metadata is built from the current input file.  Reusing a stale
+        # file left in the output directory shifts line numbers and hashes, which
+        # causes line_out_of_range/writeback mismatches on incremental reruns.
+        return input_path if input_path.exists() else target_path

--- a/module/File/RENPYHOOK.py
+++ b/module/File/RENPYHOOK.py
@@ -12,6 +12,7 @@ from module.Extract.ReplaceGenerator import (
     MISS_DIR,
     build_replace_pairs_from_entries,
     collect_hook_translation_entries,
+    filter_replace_pairs_covered_by_tl,
     write_replace_script,
 )
 from module.Extract.SimpleRpyExtractor import SimpleRpyExtractor
@@ -110,6 +111,7 @@ class RENPYHOOK(Base):
         tl_name = output_path.parent.name or "chinese"
 
         pairs = build_replace_pairs_from_entries(target_items)
+        pairs = filter_replace_pairs_covered_by_tl(pairs, target_path, tl_name)
         if pairs:
             write_replace_script(
                 output_path,

--- a/module/Renpy/renpy_extract.py
+++ b/module/Renpy/renpy_extract.py
@@ -8,6 +8,7 @@ import time
 import re
 import traceback
 import pathlib
+import ast
 
 from module.Text.SkipRules import is_path_like, is_resource_name, should_skip_text
 from utils.call_game_python import is_python2_from_game_dir
@@ -36,7 +37,6 @@ RE_RELAXED_ENGLISH_SOURCE_LINE = re.compile(
     re.IGNORECASE,
 )
 RE_RELAXED_DOUBLE_QUOTED = re.compile(r'"((?:\\.|[^"\\])*)"')
-RE_RELAXED_SINGLE_QUOTED = re.compile(r"'((?:\\.|[^'\\])*)'")
 RE_RELAXED_ENGLISH_WORD = re.compile(r'\b[A-Za-z]{3,}\b')
 RE_RELAXED_FUNCTION_CALL_PREFIX = re.compile(r'[A-Za-z_][A-Za-z0-9_\.]*\($')
 # ============================================
@@ -112,6 +112,53 @@ def is_ui_keyword(text: str) -> bool:
     return text.strip().lower() in UI_KEYWORDS
 
 
+def iter_relaxed_single_quoted_literals(line_content: str):
+    """遍历双引号外、可独立成立的单引号文本。"""
+    control_match = re.match(r'^\s*(?:if|elif|while)\b.*?:\s*(.*)$', line_content)
+    if control_match:
+        scan_line = control_match.group(1)
+        if not scan_line or scan_line.lstrip().startswith('#'):
+            return
+    else:
+        scan_line = line_content
+
+    in_double_quote = False
+    quote_start = None
+    escaped = False
+
+    for index, char in enumerate(scan_line):
+        if escaped:
+            escaped = False
+            continue
+        if char == '\\':
+            escaped = True
+            continue
+        if char == '"' and quote_start is None:
+            in_double_quote = not in_double_quote
+            continue
+        if char != "'" or in_double_quote:
+            continue
+
+        prev_char = scan_line[index - 1] if index > 0 else ''
+        next_char = scan_line[index + 1] if index + 1 < len(scan_line) else ''
+        if prev_char.isalpha() and next_char.isalpha():
+            continue
+
+        if quote_start is None:
+            if not next_char or next_char.isspace() or next_char in ",:)]}":
+                continue
+            if prev_char.isalnum() or (prev_char and prev_char in "_)]}\""):
+                continue
+            quote_start = index
+            continue
+
+        if not prev_char or prev_char.isspace() or prev_char in "([{,:":
+            continue
+        if next_char.isalnum() or next_char == '_':
+            continue
+        yield scan_line[quote_start + 1:index]
+        quote_start = None
+
 def extract_relaxed_english_line_literals(line_content: str, filter_length: int) -> set[str]:
     """按宽松英文行规则补抓引号文本。
 
@@ -127,36 +174,43 @@ def extract_relaxed_english_line_literals(line_content: str, filter_length: int)
         return set()
 
     result = set()
-    for pattern in (RE_RELAXED_DOUBLE_QUOTED, RE_RELAXED_SINGLE_QUOTED):
-        for match in pattern.finditer(line_content):
-            prefix = line_content[:match.start()].rstrip()
-            # 宽松补抓不处理明显的函数参数字符串，避免误提取菜单 ID 等内部标识。
-            if RE_RELAXED_FUNCTION_CALL_PREFIX.search(prefix):
-                continue
-            text = replace_unescaped_quotes(match.group(1))
-            text = text.replace("\\'", "'")
-            candidate = text.strip()
-            if not candidate:
-                continue
-            if RE_RELAXED_ENGLISH_WORD.search(candidate) is None:
-                continue
 
-            cmp_text = candidate.lower()
-            if is_path_or_dir_string(cmp_text) or is_resource_filename(cmp_text):
-                continue
-            if should_skip_text(candidate):
-                continue
-            if re.search(r'\[\s*\w+\.\w+.*?\]', candidate):
-                continue
+    def maybe_add_candidate(text: str):
+        candidate = text.strip()
+        if not candidate:
+            return
+        if RE_RELAXED_ENGLISH_WORD.search(candidate) is None:
+            return
 
-            effective_filter_length = filter_length
-            if contains_cjk(candidate):
-                effective_filter_length = max(2, filter_length // 3)
-            if not is_ui_keyword(candidate):
-                if len(replace_all_blank(candidate)) < effective_filter_length:
-                    continue
+        cmp_text = candidate.lower()
+        if is_path_or_dir_string(cmp_text) or is_resource_filename(cmp_text):
+            return
+        if should_skip_text(candidate):
+            return
+        if re.search(r'\[\s*\w+\.\w+.*?\]', candidate):
+            return
 
-            result.add(text)
+        effective_filter_length = filter_length
+        if contains_cjk(candidate):
+            effective_filter_length = max(2, filter_length // 3)
+        if not is_ui_keyword(candidate):
+            if len(replace_all_blank(candidate)) < effective_filter_length:
+                return
+
+        result.add(text)
+
+    for match in RE_RELAXED_DOUBLE_QUOTED.finditer(line_content):
+        prefix = line_content[:match.start()].rstrip()
+        if RE_RELAXED_FUNCTION_CALL_PREFIX.search(prefix):
+            continue
+        text = replace_unescaped_quotes(match.group(1))
+        text = text.replace("\\'", "'")
+        maybe_add_candidate(text)
+
+    for text in iter_relaxed_single_quoted_literals(line_content):
+        text = replace_unescaped_quotes(text)
+        text = text.replace("\\'", "'")
+        maybe_add_candidate(text)
 
     return result
 
@@ -237,7 +291,7 @@ def remove_repeat_extracted_from_tl(tl_dir, is_py2, cross_file_dedup=True):
     # 第二步：收集所有文件中的 old/new 对，用于跨文件去重
     # 同时收集 dialogue 块中的原文，用于删除 strings 中的冗余
     global_old_entries = {}  # {old_text: [(file_path, first_occurrence_line), ...]}
-    block_originals = set()  # {dialogue_original_text}
+    block_originals = set()  # Legacy scan result; intentionally excluded from strings de-duplication.
     
     if cross_file_dedup:
         for file_path in rpy_files:
@@ -297,13 +351,6 @@ def remove_repeat_extracted_from_tl(tl_dir, is_py2, cross_file_dedup=True):
         
         for old_text, occurrences in global_old_entries.items():
             # 情况1：如果该文本已经存在于 dialogue 翻译块中，删除 strings 中的所有条目
-            if old_text in block_originals:
-                for file_path, line_idx in occurrences:
-                    if file_path not in duplicates_to_remove:
-                        duplicates_to_remove[file_path] = set()
-                    duplicates_to_remove[file_path].add(line_idx)
-                continue
-
             # 情况2：strings 中出现多次，保留第一次
             if len(occurrences) > 1:
                 # 保留第一次出现，其余标记为待删除
@@ -549,8 +596,9 @@ def is_resource_filename(_string):
     return is_resource_name(_string)
 
 
-def ExtractFromFile(p, is_open_filter, filter_length, is_skip_underline, is_py2, skip_translate_block=False):
-    remove_repeat_for_file(p)
+def ExtractFromFile(p, is_open_filter, filter_length, is_skip_underline, is_py2, skip_translate_block=False, remove_duplicates=True):
+    if remove_duplicates:
+        remove_repeat_for_file(p)
     e = set()
     f = io.open(p, 'r+', encoding='utf-8')
     _read = f.read()
@@ -719,10 +767,10 @@ def ExtractFromFile(p, is_open_filter, filter_length, is_skip_underline, is_py2,
         if is_add:
             continue
         single_quote_line = d.get('encoded', line_content)
-        control_match = re.match(r'^\s*(?:if|elif|while)\b.*:\s*(.*)$', single_quote_line)
+        control_match = re.match(r'^\s*(?:if|elif|while)\b.*?:\s*(.*)$', single_quote_line)
         if control_match:
             single_quote_line = control_match.group(1)
-            if not single_quote_line or single_quote_line.startswith('#'):
+            if not single_quote_line or single_quote_line.lstrip().startswith('#'):
                 continue
         d = EncodeBracketContent(single_quote_line, "'", "'")
         if 'oriList' in d.keys() and len(d['oriList']) > 0:
@@ -945,6 +993,79 @@ def ExtractWriteFile(p, tl_name, is_open_filter, filter_length, is_gen_empty, gl
     global_e = global_e | extractedSet
     log.info(target + ' extracted success!')
     return global_e
+
+
+def collect_static_menu_strings(game_dir):
+    """Collect menu-choice text and prefer its first real source location."""
+    from pathlib import Path
+
+    root = Path(game_dir)
+    source_root = root / "game" if (root / "game").is_dir() else root
+    result = {}
+    menu_choice_re = re.compile(
+        r'^\s*"(?P<text>(?:\\.|[^"\\])*)"\s*(?:\([^)]*\))?\s*:\s*(?:#.*)?$'
+    )
+    if not source_root.is_dir():
+        return result
+    for source_file in sorted(source_root.rglob("*.rpy"), key=lambda item: item.as_posix()):
+        relative = source_file.relative_to(source_root)
+        if relative.parts and relative.parts[0].lower() == "tl":
+            continue
+        try:
+            lines = source_file.read_text(encoding="utf-8", errors="replace").splitlines()
+        except Exception:
+            continue
+        for line in lines:
+            match = menu_choice_re.match(line)
+            if not match:
+                continue
+            raw = match.group("text")
+            try:
+                text = ast.literal_eval(f'"{raw}"')
+            except Exception:
+                text = raw.replace('\\"', '"').replace("\\'", "'")
+            if text:
+                result.setdefault(text, relative.as_posix())
+    return result
+
+
+def collect_static_source_strings(game_dir, is_open_filter=True, filter_length=4, is_skip_underline=False):
+    """收集可写入 translate strings 的静态源码文本，同文仅保留排序后的首次出现。"""
+    from pathlib import Path
+
+    root = Path(game_dir)
+    source_root = root / "game" if (root / "game").is_dir() else root
+    candidates = {}
+    if not source_root.is_dir():
+        return candidates
+
+    is_py2 = is_python2_from_game_dir(str(source_root))
+    menu_map = collect_static_menu_strings(game_dir)
+    menu_candidates = set(menu_map)
+    for source_file in sorted(source_root.rglob("*.rpy"), key=lambda item: item.as_posix()):
+        try:
+            relative = source_file.relative_to(source_root)
+        except ValueError:
+            continue
+        if relative.parts and relative.parts[0].lower() == "tl":
+            continue
+        try:
+            # 源码扫描不可调用带写入前处理的旧接口，避免修改游戏原文。
+            texts = ExtractFromFile(
+                str(source_file), is_open_filter, filter_length, is_skip_underline,
+                is_py2, True, False,
+            )
+        except Exception:
+            continue
+        # Menu choices require a strings translation even when the same text
+        # first appears as dialogue in another file. Prefer their real menu
+        # location and do not discard short choices such as "No.".
+        for text in sorted(texts):
+            text = text.replace('\\"', '"').replace("\\'", "'")
+            if text and not should_skip_text(text):
+                candidates.setdefault(text, relative.as_posix())
+    candidates.update(menu_map)
+    return candidates
 
 
 def ExtractAllFilesInDir(dirName, is_open_filter, filter_length, is_gen_empty, is_skip_underline):

--- a/tests/module/test_renpy_extract.py
+++ b/tests/module/test_renpy_extract.py
@@ -1,4 +1,15 @@
-from module.Renpy.renpy_extract import ExtractFromFile
+from module.Renpy.renpy_extract import ExtractFromFile, remove_repeat_extracted_from_tl
+from module.Renpy import renpy_extract as rx
+from module.Extract.ReplaceGenerator import (
+    _extract_relaxed_english_line_literals,
+    _try_load_regex_cache,
+    filter_replace_pairs_covered_by_tl,
+    render_replace_script,
+)
+from module.Extract.UnifiedExtractor import UnifiedExtractor
+import types
+from enum import Enum
+from pathlib import Path
 
 
 def extract_from_text(tmp_path, content: str, filter_length: int = 20) -> set[str]:
@@ -40,6 +51,27 @@ def test_extract_from_file_ignores_contraction_apostrophes_inside_double_quotes(
     assert result == set()
 
 
+def test_extract_from_file_keeps_double_quoted_dialogue_with_nested_single_quotes(tmp_path):
+    content = '''speaker "I've got thirty seconds to calibrate the console and prime its 'aux-power' gauge."
+'''
+
+    result = extract_from_text(tmp_path, content, filter_length=4)
+
+    assert "I've got thirty seconds to calibrate the console and prime its 'aux-power' gauge." in result
+    assert "ve got thirty seconds to calibrate the console and prime its " not in result
+    assert "o-power" not in result
+
+
+def test_extract_from_file_keeps_double_quoted_dialogue_with_contractions(tmp_path):
+    content = '''speaker "Oh, captain... it's a triple signal!"
+'''
+
+    result = extract_from_text(tmp_path, content, filter_length=4)
+
+    assert "Oh, captain... it's a triple signal!" in result
+    assert "s a triple signal!" not in result
+
+
 def test_extract_from_file_ignores_single_quoted_control_conditions(tmp_path):
     content = '''if state == 'start':
     pass
@@ -54,3 +86,650 @@ if ready: 'Inline translatable text'
 
     assert {"start", "middle", "loop"}.isdisjoint(result)
     assert "Inline translatable text" in result
+
+
+def test_extract_from_file_keeps_single_quoted_display_text_outside_double_quotes(tmp_path):
+    content = '''show text 'Single quoted display text'
+'''
+
+    result = extract_from_text(tmp_path, content, filter_length=4)
+
+    assert "Single quoted display text" in result
+
+
+
+def test_replace_text_relaxed_scan_ignores_apostrophes_in_dialogue():
+    line = 'speaker "I\'ve got forty seconds to refill the engine and prime its \'aux-drive\' gauge."'
+
+    result = _extract_relaxed_english_line_literals(line)
+
+    assert "I've got forty seconds to refill the engine and prime its 'aux-drive' gauge." in result
+    assert 've got forty seconds to refill the engine and prime its ' not in result
+    assert 'aux-drive' not in result
+    assert _extract_relaxed_english_line_literals("show text 'Standalone display text'") == {"Standalone display text"}
+
+
+def test_incremental_coverage_ignores_translate_block_comments(tmp_path):
+    translation_file = tmp_path / "dialogue.rpy"
+    translation_file.write_text(
+        'translate chinese scene_demo:\n'
+        '    # narrator "I won\'t decline."\n'
+        '    narrator "Already translated"\n',
+        encoding="utf-8",
+    )
+    extractor = UnifiedExtractor.__new__(UnifiedExtractor)
+    extractor.logger = types.SimpleNamespace(debug=lambda *args, **kwargs: None)
+
+    covered = extractor._get_all_originals(tmp_path)
+
+    assert "I will reconsider." not in covered
+
+
+def test_incremental_selection_uses_blocks_for_coverage_but_keeps_menu_exception(tmp_path):
+    tl_dir = tmp_path / "tl" / "chinese"
+    ano = tl_dir / "src" / "plot" / "chapter_beta.rpy"
+    dialogue = tl_dir / "src" / "plot" / "dialogue.rpy"
+    ano.parent.mkdir(parents=True)
+    ano.write_text("", encoding="utf-8")
+    dialogue.write_text(
+        'translate chinese scene_demo:\n\n'
+        '    # narrator "Already translated dialogue."\n'
+        '    narrator "已经翻译的对话。"\n\n'
+        'translate chinese scene_same_text:\n\n'
+        '    # narrator "I can proceed."\n'
+        '    narrator "我不介意。"\n',
+        encoding="utf-8",
+    )
+
+    extractor = UnifiedExtractor.__new__(UnifiedExtractor)
+    extracted = {"Already translated dialogue.", "I can proceed.", "Brand new text."}
+    selected = extractor._select_incremental_originals(
+        extracted_originals=extracted,
+        existing_string_originals=set(),
+        block_originals={"Already translated dialogue.", "I can proceed."},
+        static_candidates={"I can proceed.": "src/plot/chapter_beta.rpy"},
+        tl_dir=tl_dir,
+    )
+
+    assert selected == {"I can proceed.", "Brand new text."}
+
+
+def test_pending_strings_placeholder_survives_equal_dialogue_coverage():
+    pending = {"I can proceed.", "Synthetic dialogue placeholder."}
+    existing_strings = {"I can proceed."}
+    block_originals = {"I can proceed.", "Synthetic dialogue placeholder."}
+
+    pending -= block_originals - existing_strings
+
+    assert pending == {"I can proceed."}
+
+
+def test_static_supplement_accepts_official_comment_missing_closing_parenthesis(tmp_path):
+    tl_dir = tmp_path / "tl" / "chinese"
+    target = tl_dir / "src" / "plot" / "chapter_beta.rpy"
+    target.parent.mkdir(parents=True)
+    target.write_text(
+        'translate chinese chapter_beta_demo:\n\n'
+        '    # anon "( I can\'t believe it! "\n'
+        '    anon "（我真不敢相信！）"\n',
+        encoding="utf-8",
+    )
+    extractor = UnifiedExtractor.__new__(UnifiedExtractor)
+
+    assert extractor._is_covered_by_file_block(
+        "( I can't believe it! )", {"( I can't believe it! "}
+    )
+
+
+def test_cleanup_removes_truncated_comment_duplicate_but_keeps_menu_string(tmp_path):
+    target = tmp_path / "chapter_beta.rpy"
+    target.write_text(
+        'translate chinese scene_demo:\n\n'
+        '    # anon "( I can\'t believe it! "\n'
+        '    anon "（我真不敢相信！）"\n\n'
+        'translate chinese strings:\n\n'
+        '    old "( I can\'t believe it! )"\n'
+        '    new "（我真不敢相信！）"\n\n'
+        '    old "I can proceed."\n'
+        '    new "我不介意。"\n',
+        encoding="utf-8",
+    )
+    extractor = UnifiedExtractor.__new__(UnifiedExtractor)
+    extractor.logger = types.SimpleNamespace(debug=lambda *args, **kwargs: None)
+
+    assert extractor._remove_strings_covered_by_truncated_block_comment(tmp_path) == 1
+    content = target.read_text(encoding="utf-8")
+    assert 'old "( I can\'t believe it! )"' not in content
+    assert 'old "I can proceed."' in content
+
+
+def test_incremental_repairs_official_comment_from_anchored_source_line(tmp_path):
+    project = tmp_path / "project"
+    source = project / "game" / "src" / "plot" / "chapter_beta.rpy"
+    tl = project / "game" / "tl" / "chinese" / "src" / "plot" / "chapter_beta.rpy"
+    source.parent.mkdir(parents=True)
+    tl.parent.mkdir(parents=True)
+    source.write_text(
+        'anon "( I can\'t believe I just crossed the portal with [story.partner]! )"\n',
+        encoding="utf-8",
+    )
+    tl.write_text(
+        '# game/src/plot/chapter_beta.rpy:1\n'
+        'translate chinese chapter_beta_demo:\n\n'
+        '    # anon "( I can\'t believe I just crossed the portal with [story.partner]! "\n'
+        '    anon "（我真不敢相信！）"\n',
+        encoding="utf-8",
+    )
+    extractor = UnifiedExtractor.__new__(UnifiedExtractor)
+    extractor.logger = types.SimpleNamespace(debug=lambda *args, **kwargs: None)
+
+    assert extractor._repair_block_comments_from_source(
+        project, project / "game" / "tl" / "chinese"
+    ) == 1
+    repaired = tl.read_text(encoding="utf-8")
+    assert '# anon "( I can\'t believe I just crossed the portal with [story.partner]! )"' in repaired
+
+
+def test_collect_block_originals_accepts_legacy_enum_string_form(tmp_path, monkeypatch):
+    class LegacyKind(Enum):
+        LABEL = "LABEL"
+
+    translation_file = tmp_path / "dialogue.rpy"
+    translation_file.write_text(
+        'translate chinese scene_demo:\n\n'
+        '    # narrator "Already translated dialogue."\n'
+        '    narrator "已经翻译的对话。"\n',
+        encoding="utf-8",
+    )
+    item = types.SimpleNamespace(
+        get_src=lambda: "Already translated dialogue.",
+        get_extra_field=lambda: {"renpy": {"block": {"kind": LegacyKind.LABEL}}},
+    )
+
+    from module.Extract import UnifiedExtractor as ux
+
+    monkeypatch.setattr(ux, "parse_tl_document", lambda lines: object())
+    monkeypatch.setattr(
+        ux.RenpyTlItemExtractor,
+        "extract",
+        lambda self, doc, path: [item],
+    )
+    extractor = UnifiedExtractor.__new__(UnifiedExtractor)
+    extractor.logger = types.SimpleNamespace(debug=lambda *args, **kwargs: None)
+
+    assert extractor._collect_block_originals(tmp_path) == {"Already translated dialogue."}
+
+
+def test_onekey_incremental_translation_uses_delta_but_applies_to_main_tl(tmp_path):
+    from frontend.RenpyToolbox.OneKeyTranslatePage import (
+        configure_incremental_translation_paths,
+    )
+
+    project = tmp_path / "project"
+    delta = project / "game" / "tl" / "chinese_new"
+    config = types.SimpleNamespace(input_folder="old-input", output_folder="old-output")
+
+    apply_target, output = configure_incremental_translation_paths(
+        config, project, "chinese", delta
+    )
+
+    assert Path(config.input_folder) == delta
+    assert Path(config.output_folder) == project / "RenpyBox_Translation" / "chinese_new"
+    assert output == Path(config.output_folder)
+    assert apply_target == project / "game" / "tl" / "chinese"
+
+
+def test_replace_text_rebuilds_outdated_regex_cache(tmp_path):
+    cache_path = tmp_path / "regex_extracted.json"
+    cache_path.write_text(
+        '{"version": 1, "file_count": 1, "max_mtime_ns": 1, "strings": ["stale fragment"]}',
+        encoding="utf-8",
+    )
+
+    assert _try_load_regex_cache(cache_path, file_count=1, max_mtime_ns=1) is None
+
+
+def test_incremental_merge_cleans_staging_folder_and_base_box_placeholders(tmp_path):
+    game_dir = tmp_path / "project"
+    tl_dir = game_dir / "game" / "tl" / "chinese"
+    staging_dir = game_dir / "game" / "tl" / "chinese_new"
+    base_box = tl_dir / "base_box"
+    base_box.mkdir(parents=True)
+    staging_dir.mkdir(parents=True)
+
+    (base_box / "screens_box.rpy").write_text(
+        'translate chinese strings:\n\n    old "Back"\n    new "\u8fd4\u56de"\n',
+        encoding="utf-8",
+    )
+    hud = tl_dir / "src" / "gui" / "hud.rpy"
+    hud.parent.mkdir(parents=True)
+    hud.write_text(
+        'translate chinese strings:\n\n    old "Back"\n    new "回来"\n',
+        encoding="utf-8",
+    )
+    staging = staging_dir / "src" / "plot" / "new_text.rpy"
+    staging.parent.mkdir(parents=True)
+    staging.write_text(
+        'translate chinese strings:\n\n    old "New menu text"\n    new "\u65b0\u83dc\u5355\u6587\u672c"\n',
+        encoding="utf-8",
+    )
+
+    extractor = UnifiedExtractor.__new__(UnifiedExtractor)
+    extractor.logger = types.SimpleNamespace(
+        debug=lambda *args, **kwargs: None,
+        info=lambda *args, **kwargs: None,
+        warning=lambda *args, **kwargs: None,
+    )
+    result = extractor.merge_incremental_folder(game_dir, "chinese", staging_dir, clean_duplicates=True)
+
+    assert result.success
+    assert not staging_dir.exists()
+    assert 'old "Back"' not in hud.read_text(encoding="utf-8")
+    assert 'old "New menu text"' in (tl_dir / "src" / "plot" / "new_text.rpy").read_text(encoding="utf-8")
+
+
+def test_incremental_merge_reuses_strings_block_and_keeps_source_location(tmp_path):
+    game_dir = tmp_path / "project"
+    tl_dir = game_dir / "game" / "tl" / "chinese"
+    staging_dir = game_dir / "game" / "tl" / "chinese_new"
+    target = tl_dir / "src" / "plot" / "chapter_beta.rpy"
+    staging = staging_dir / "src" / "plot" / "chapter_beta.rpy"
+    target.parent.mkdir(parents=True)
+    staging.parent.mkdir(parents=True)
+    target.write_text(
+        'translate chinese strings:\n\n    old "Existing"\n    new "已有"\n',
+        encoding="utf-8",
+    )
+    staging.write_text(
+        'translate chinese strings:\n\n'
+        '    # game/src/plot/chapter_beta.rpy:1635\n'
+        '    old "I can proceed."\n'
+        '    new "我不介意。"\n',
+        encoding="utf-8",
+    )
+
+    extractor = UnifiedExtractor.__new__(UnifiedExtractor)
+    extractor.logger = types.SimpleNamespace(
+        debug=lambda *args, **kwargs: None,
+        info=lambda *args, **kwargs: None,
+        warning=lambda *args, **kwargs: None,
+    )
+    result = extractor.merge_incremental_folder(
+        game_dir, "chinese", staging_dir, clean_duplicates=False
+    )
+
+    assert result.success
+    content = target.read_text(encoding="utf-8")
+    assert content.count("translate chinese strings:") == 1
+    assert "# 增量合并" not in content
+    assert "# game/src/plot/chapter_beta.rpy:1635" in content
+    assert 'old "I can proceed."' in content
+
+
+def test_removes_strings_already_registered_by_game_source(tmp_path):
+    game_dir = tmp_path / "project"
+    source = game_dir / "game" / "src" / "renpy" / "confirm.rpy"
+    translated = game_dir / "game" / "tl" / "chinese" / "src" / "renpy" / "confirm.rpy"
+    source.parent.mkdir(parents=True)
+    translated.parent.mkdir(parents=True)
+    duplicate = "To review the continued operation of this demo you can go to:"
+    source.write_text(
+        "translate chinese strings:\n\n"
+        f'    old "{duplicate}"\n'
+        '    new "源码已经注册"\n',
+        encoding="utf-8",
+    )
+    translated.write_text(
+        "translate chinese strings:\n\n"
+        "    # game/src/renpy/confirm.rpy:6\n"
+        f'    old "{duplicate}"\n'
+        '    new "重复生成"\n\n'
+        '    old "Only in TL"\n'
+        '    new "只在翻译目录"\n',
+        encoding="utf-8",
+    )
+
+    extractor = UnifiedExtractor.__new__(UnifiedExtractor)
+    removed = extractor._remove_source_registered_string_duplicates(
+        game_dir, game_dir / "game" / "tl" / "chinese", "chinese"
+    )
+
+    assert removed == 1
+    content = translated.read_text(encoding="utf-8")
+    assert duplicate not in content
+    assert "# game/src/renpy/confirm.rpy:6" not in content
+    assert 'old "Only in TL"' in content
+
+
+def test_incremental_merge_canonicalizes_double_escaped_quote_duplicates(tmp_path):
+    game_dir = tmp_path / "project"
+    tl_dir = game_dir / "game" / "tl" / "chinese"
+    staging_dir = game_dir / "game" / "tl" / "chinese_new"
+    target = tl_dir / "src" / "mini" / "pc.rpy"
+    staging = staging_dir / "src" / "mini" / "pc.rpy"
+    target.parent.mkdir(parents=True)
+    staging.parent.mkdir(parents=True)
+
+    target.write_text(
+        'translate chinese strings:\n\n'
+        '    old "- Training Bot \\"Copper Finch\\""\n'
+        '    new "性爱娃娃「Copper Finch」"\n',
+        encoding="utf-8",
+    )
+    staging.write_text(
+        'translate chinese strings:\n\n'
+        '    old "- Training Bot \\\\\\"Copper Finch\\\\\\""\n'
+        '    new "- 性爱娃娃 \\\\"肮脏的哈罗德\\\\""\n',
+        encoding="utf-8",
+    )
+
+    extractor = UnifiedExtractor.__new__(UnifiedExtractor)
+    extractor.logger = types.SimpleNamespace(
+        debug=lambda *args, **kwargs: None,
+        info=lambda *args, **kwargs: None,
+        warning=lambda *args, **kwargs: None,
+    )
+    result = extractor.merge_incremental_folder(
+        game_dir, "chinese", staging_dir, clean_duplicates=True
+    )
+
+    assert result.success
+    content = target.read_text(encoding="utf-8")
+    assert content.count('old "- Training Bot') == 1
+    assert '\\\\\\"Copper Finch' not in content
+
+
+def test_incremental_static_supplement_reaches_corresponding_tl_file(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    source = project / "game" / "src" / "plot" / "chapter_beta.rpy"
+    source.parent.mkdir(parents=True)
+    source.write_text(
+        'menu:\n'
+        '    "That signal is making me uneasy.":\n'
+        '        pass\n'
+        '    "I can proceed."(_choice=\'poly\'):\n'
+        '        jump poly\n',
+        encoding="utf-8",
+    )
+
+    extractor = UnifiedExtractor.__new__(UnifiedExtractor)
+    extractor.logger = types.SimpleNamespace(
+        info=lambda *args, **kwargs: None,
+        warning=lambda *args, **kwargs: None,
+        debug=lambda *args, **kwargs: None,
+    )
+    tl_dir = project / "_temp" / "game" / "tl" / "chinese"
+
+    assert extractor._append_static_supplement_entries(project, tl_dir, "chinese") == 2
+    output = tl_dir / "src" / "plot" / "chapter_beta.rpy"
+    content = output.read_text(encoding="utf-8")
+    assert 'old "I can proceed."' in content
+
+    incremental_dir = project / "game" / "tl" / "chinese_new"
+    extractor._extract_new_entries_to_folder(
+        tl_dir, incremental_dir, {"I can proceed."}, "chinese"
+    )
+    incremental = incremental_dir / "src" / "plot" / "chapter_beta.rpy"
+    assert incremental.exists()
+    assert 'old "I can proceed."' in incremental.read_text(encoding="utf-8")
+
+
+def test_global_dedup_keeps_menu_string_equal_to_dialogue_comment(tmp_path):
+    dialogue = tmp_path / "dialogue.rpy"
+    menu = tmp_path / "menu.rpy"
+    dialogue.write_text(
+        'translate chinese scene_demo:\n\n'
+        '    # narrator "I can proceed."\n'
+        '    narrator "我不介意。"\n',
+        encoding="utf-8",
+    )
+    menu.write_text(
+        'translate chinese strings:\n\n'
+        '    old "I can proceed."\n'
+        '    new "我不介意。"\n',
+        encoding="utf-8",
+    )
+
+    remove_repeat_extracted_from_tl(str(tmp_path), is_py2=False)
+
+    assert 'old "I can proceed."' in menu.read_text(encoding="utf-8")
+
+
+
+def test_static_supplement_uses_first_source_file_for_duplicate_menu_text(tmp_path):
+    project = tmp_path / "project"
+    first_source = project / "game" / "src" / "chapter01.rpy"
+    second_source = project / "game" / "src" / "chapter02.rpy"
+    first_source.parent.mkdir(parents=True)
+    first_source.write_text(
+        "menu:\n"
+        "    \"Continue route.\"(_choice='continue'):\n"
+        "        pass\n",
+        encoding="utf-8",
+    )
+    second_source.write_text(
+        "menu:\n"
+        "    \"Continue route.\"(_choice='continue'):\n"
+        "        pass\n"
+        '    narrator "Signal says \\"ready\\"."\n',
+        encoding="utf-8",
+    )
+
+    candidates = rx.collect_static_source_strings(project)
+    assert candidates["Continue route."] == "src/chapter01.rpy"
+    assert candidates['Signal says "ready".'] == "src/chapter02.rpy"
+
+    extractor = UnifiedExtractor.__new__(UnifiedExtractor)
+    extractor.logger = types.SimpleNamespace(info=lambda *args, **kwargs: None)
+    tl_dir = project / "_temp" / "game" / "tl" / "chinese"
+    assert extractor._append_static_supplement_entries(project, tl_dir, "chinese") >= 1
+
+    first_tl = tl_dir / "src" / "chapter01.rpy"
+    second_tl = tl_dir / "src" / "chapter02.rpy"
+    assert 'old "Continue route."' in first_tl.read_text(encoding="utf-8")
+    assert 'old "Continue route."' not in second_tl.read_text(encoding="utf-8")
+
+    dialogue_tl = tl_dir / "dialogue.rpy"
+    dialogue_tl.write_text(
+        'translate chinese scene_demo:\n'
+        '    # narrator "Continue route."\n'
+        '    narrator "Existing dialogue"\n',
+        encoding="utf-8",
+    )
+    assert extractor._remove_string_duplicates_with_blocks(tl_dir) == 0
+    assert 'old "Continue route."' in first_tl.read_text(encoding="utf-8")
+
+
+def test_replace_text_relaxed_scan_matches_standard_extractor_for_control_lines():
+    assert _extract_relaxed_english_line_literals("if state == 'start':") == set()
+    assert _extract_relaxed_english_line_literals("if ready: 'Inline translatable text'") == {"Inline translatable text"}
+
+
+def test_regular_extract_appends_static_supplement_entries(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    source = project / "game" / "script.rpy"
+    source.parent.mkdir(parents=True)
+    source.write_text(
+        "label start:\n"
+        "    show text 'Standalone display text'\n",
+        encoding="utf-8",
+    )
+
+    from module.Extract import UnifiedExtractor as ux
+
+    monkeypatch.setattr(
+        ux.Config,
+        "load",
+        lambda self: types.SimpleNamespace(
+            extract_use_official=False,
+            extract_use_custom=True,
+            onekey_inject_base_box=False,
+            renpy_remove_string_duplicates=False,
+            export_structured_json=False,
+            export_trans_json=False,
+        ),
+    )
+    monkeypatch.setattr(rx, "ExtractAllFilesInDir", lambda *args, **kwargs: None)
+
+    extractor = UnifiedExtractor.__new__(UnifiedExtractor)
+    extractor.logger = types.SimpleNamespace(
+        info=lambda *args, **kwargs: None,
+        debug=lambda *args, **kwargs: None,
+        warning=lambda *args, **kwargs: None,
+        error=lambda *args, **kwargs: None,
+    )
+    extractor.renpy_extractor = None
+    extractor._progress_callback = None
+    extractor._last_suspicious_manifest = None
+    extractor._last_suspicious_removed_count = 0
+
+    result = extractor.extract_regular(project, "chinese", use_official=False)
+
+    assert result.success
+    output = project / "game" / "tl" / "chinese" / "script.rpy"
+    assert 'old "Standalone display text"' in output.read_text(encoding="utf-8")
+
+
+def test_static_candidates_prefer_menu_location_and_keep_short_choices(tmp_path):
+    project = tmp_path / "project"
+    dialogue = project / "game" / "src" / "plot" / "chapter_alpha.rpy"
+    menu = project / "game" / "src" / "plot" / "chapter_beta.rpy"
+    dialogue.parent.mkdir(parents=True)
+    dialogue.write_text('anon "Proceed."\n', encoding="utf-8")
+    menu.write_text(
+        'menu:\n    "Proceed."(_choice=\'ogle\'):\n        pass\n    "Decline.":\n        pass\n',
+        encoding="utf-8",
+    )
+
+    candidates = rx.collect_static_source_strings(project)
+
+    assert candidates["Proceed."] == "src/plot/chapter_beta.rpy"
+    assert candidates["Decline."] == "src/plot/chapter_beta.rpy"
+
+    target = project / "game" / "tl" / "chinese" / "src" / "plot" / "chapter_beta.rpy"
+    target.parent.mkdir(parents=True)
+    target.write_text(
+        'translate chinese chapter_beta_dialogue:\n\n'
+        '    # anon "Proceed."\n'
+        '    anon "当然。"\n',
+        encoding="utf-8",
+    )
+    extractor = UnifiedExtractor.__new__(UnifiedExtractor)
+    extractor.logger = types.SimpleNamespace(info=lambda *args, **kwargs: None)
+
+    added = extractor._append_static_supplement_entries(
+        project, project / "game" / "tl" / "chinese", "chinese"
+    )
+
+    content = target.read_text(encoding="utf-8")
+    assert added >= 2
+    assert 'old "Proceed."' in content
+    assert 'old "Decline."' in content
+
+
+def test_replace_hook_unwraps_previous_generated_hook_on_reload():
+    script = render_replace_script([("old", "new")])
+
+    assert 'while getattr(_renpybox_replace_text_previous, "_renpybox_auto_hook", False)' in script
+    assert "_renpybox_seen_hooks" in script
+    assert "if _renpybox_next_hook is _renpybox_replace_text_previous" in script
+    assert "renpybox_replace_text_auto._renpybox_auto_hook = True" in script
+    assert "renpybox_replace_text_auto._renpybox_previous = _renpybox_replace_text_previous" in script
+    assert "_renpybox_previous=_renpybox_replace_text_previous" in script
+
+
+def test_replace_hook_omits_text_now_covered_by_normal_tl(tmp_path):
+    game = tmp_path / "game"
+    tl_file = game / "tl" / "chinese" / "src" / "menu" / "pref.rpy"
+    tl_file.parent.mkdir(parents=True)
+    tl_file.write_text(
+        'translate chinese strings:\n\n'
+        '    old "Turn this off to have a more pleasant viewing experience."\n'
+        '    new "关闭此选项可获得更愉悦的浏览体验。"\n',
+        encoding="utf-8",
+    )
+
+    pairs = filter_replace_pairs_covered_by_tl(
+        [("Turn this off", "关闭此选项"), ("Hook only", "仅钩子")],
+        game,
+        "chinese",
+    )
+
+    assert pairs == [("Hook only", "仅钩子")]
+
+
+def test_replace_hook_omits_untranslated_old_placeholder(tmp_path):
+    game = tmp_path / "game"
+    tl_file = game / "tl" / "chinese" / "src" / "menu" / "slot.rpy"
+    tl_file.parent.mkdir(parents=True)
+    tl_file.write_text(
+        'translate chinese strings:\n\n'
+        '    old "Q{#quick_page}"\n'
+        '    new "Q{#quick_page}"\n',
+        encoding="utf-8",
+    )
+
+    pairs = filter_replace_pairs_covered_by_tl(
+        [("Q{#quick_page}", "Q页"), ("Hook only", "仅钩子")], game, "chinese"
+    )
+
+    assert pairs == [("Hook only", "仅钩子")]
+
+
+def test_menu_string_is_incremental_even_when_dialogue_block_exists(tmp_path):
+    project = tmp_path / "project"
+    source = project / "game" / "src" / "plot" / "chapter_beta.rpy"
+    target = project / "game" / "tl" / "chinese" / "src" / "plot" / "chapter_beta.rpy"
+    source.parent.mkdir(parents=True)
+    target.parent.mkdir(parents=True)
+    source.write_text('menu:\n    "Proceed.":\n        pass\n', encoding="utf-8")
+    target.write_text(
+        'translate chinese chapter_beta_dialogue:\n\n'
+        '    # anon "Proceed."\n'
+        '    anon "当然。"\n',
+        encoding="utf-8",
+    )
+    extractor = UnifiedExtractor.__new__(UnifiedExtractor)
+
+    selected = extractor._select_incremental_originals(
+        {"Proceed."}, set(), {"Proceed."},
+        {"Proceed.": "src/plot/chapter_beta.rpy"},
+        project / "game" / "tl" / "chinese",
+    )
+
+    assert selected == {"Proceed."}
+
+
+def test_incremental_menu_string_uses_real_menu_file_and_line(tmp_path):
+    project = tmp_path / "project"
+    source_chapter_alpha = project / "game" / "src" / "plot" / "chapter_alpha.rpy"
+    source_chapter_beta = project / "game" / "src" / "plot" / "chapter_beta.rpy"
+    extracted = project / "temp" / "src" / "plot" / "chapter_alpha.rpy"
+    target = project / "game" / "tl" / "chinese_new"
+    source_chapter_alpha.parent.mkdir(parents=True)
+    extracted.parent.mkdir(parents=True)
+    source_chapter_alpha.write_text('anon "Proceed."\n', encoding="utf-8")
+    source_chapter_beta.write_text(
+        'anon "Proceed."\nmenu:\n    "Proceed."(_choice="ogle"):\n        pass\n',
+        encoding="utf-8",
+    )
+    extracted.write_text(
+        'translate chinese chapter_alpha_dialogue:\n\n'
+        '    # anon "Proceed."\n'
+        '    anon "Proceed."\n\n'
+        'translate chinese strings:\n\n'
+        '    old "Proceed."\n'
+        '    new "Proceed."\n',
+        encoding="utf-8",
+    )
+    extractor = UnifiedExtractor.__new__(UnifiedExtractor)
+    extractor.logger = types.SimpleNamespace(warning=lambda *args, **kwargs: None)
+
+    extractor._extract_new_entries_to_folder(
+        project / "temp", target, {"Proceed."}, "chinese", project
+    )
+
+    assert not (target / "src" / "plot" / "chapter_alpha.rpy").exists()
+    content = (target / "src" / "plot" / "chapter_beta.rpy").read_text(encoding="utf-8")
+    assert content.count('old "Proceed."') == 1
+    assert "# game/src/plot/chapter_beta.rpy:3" in content


### PR DESCRIPTION
## 背景

Ren’Py 的一键翻译与增量翻译流程中，官方抽取、补充抽取、漏翻补全和翻译回写之间缺少统一的覆盖关系判断，可能造成文本被错误截取、菜单选项漏翻、增量内容重复生成，以及同一原文在多个位置注册而导致游戏启动失败。

## 主要修改

### 文本抽取

- 修复双引号对话中包含缩写或成对单引号时的异常截取，避免将完整句子拆成错误片段。
- 统一标准抽取与宽松扫描的引号处理逻辑，过滤控制条件、代码表达式及其他不应翻译的内容。
- 补充识别带参数、条件或特殊后缀的菜单选项，确保菜单文本进入标准 old/new 翻译流程。
- 菜单字符串按照真实菜单首次出现的位置输出，不再错误复用其他文件中的同文对话块。

### 增量翻译流程

- 增量抽取仅输出真正新增或仍待翻译的条目，避免已有翻译被重复送入翻译任务。
- 保留 chinese_new 暂存目录直至翻译完成，再将结果合并回主翻译目录。
- 增量 old/new 直接追加到已有的 translate strings 块，不再创建多余区块或辅助注释。
- 在增量目录生成阶段写入对应的原文文件路径和行号，便于后续合并、检查与问题定位。
- 修复特殊菜单文本被同文对话翻译误判为已覆盖的问题。

### 翻译唯一性与冲突处理

- 对翻译目录内的 old/new 进行统一去重，确保同一原文只注册一次。
- 清理普通翻译与内置界面翻译之间的重复项，并以内置界面翻译为准。
- 检测游戏源码中已经直接注册的字符串翻译，避免在 game/tl 下再次生成相同条目。
- 修复官方翻译注释缺少结尾括号时产生的重复补充条目，并根据原文锚点修正不完整注释。
- 合并增量内容时保留已有有效译文，只使用新译文补全空值或原文占位。

### 文本替换钩子

- 仅为标准 Ren’Py 翻译无法覆盖的文本生成 replace_text_auto.rpy。
- 在写入钩子前重新检查普通 TL 覆盖情况，避免同一文本同时由 old/new 和替换钩子处理。
- 修复自动钩子重复加载后形成自引用链并触发递归溢出的问题。
- 对历史自动钩子进行安全解包，保留原有非自动文本替换函数。

### 应用与回写

- 修复增量翻译输出目录与最终应用目录之间的路径关系。
- 确保完成翻译后能够正常合并到主语言目录，并清理已处理的暂存内容。
- 修复部分运行环境中枚举值表示方式不同导致的翻译块覆盖判断失效。

## 验证结果

- 40 项自动化测试全部通过。
- Python 编译检查通过。
- 覆盖嵌套引号、特殊菜单、增量筛选、来源行号、跨目录去重、源码翻译冲突和文本替换钩子递归等场景。